### PR TITLE
:bug: (halam/#185) 페이지네이션 - 페이지그룹에서 0 이하의 페이지 번호가 나오는 이슈 해결

### DIFF
--- a/money-for-rabbit/src/pages/letter/LetterList.jsx
+++ b/money-for-rabbit/src/pages/letter/LetterList.jsx
@@ -46,6 +46,9 @@ function LetterList() {
     }
 
     let firstNumber = lastNumber - (pageCount - 1);
+    if (firstNumber < 1) {
+      firstNumber = 1;
+    }
     let pageNumList = [];
 
     const next = lastNumber + 1;


### PR DESCRIPTION
|이슈|이슈 해결|
|--|--|
| <img width="384" alt="image" src="https://user-images.githubusercontent.com/87893624/213691241-413f1e14-ca08-4cfc-b299-c85b792abe3f.png">| <img width="384" alt="image" src="https://user-images.githubusercontent.com/87893624/213689901-98f3c506-e589-4945-ad9f-42ff932902b4.png">